### PR TITLE
Add schedule aggregation skeleton

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,21 @@
+# 일정 수집 및 Markdown 관리 도구
+
+이 프로젝트는 매일 22:00(한국시간)에 사용자의 일정 정리 여부를 확인한 뒤,
+다양한 메시지 서비스에서 일정 관련 내용을 수집하여 Markdown 형식으로
+저장하는 간단한 예제입니다.
+
+## 구성 요소
+- `aggregator/main.py`: 스케줄러와 수집 로직의 진입점
+- `fetchers/`: 각 서비스별 메시지 수집 모듈 (구현 필요)
+- `parser.py`: 메시지에서 날짜 형식을 찾아 일정 문장으로 추출
+- `markdown_writer.py`: Obsidian Vault 등에 저장할 Markdown 파일 작성
+
+## 사용 방법
+1. 필요한 라이브러리 설치
+   ```bash
+   pip install schedule pytz
+   ```
+2. `VAULT_PATH` 환경변수로 Markdown을 저장할 디렉터리를 지정합니다.
+3. `python aggregator/main.py` 실행 후 안내에 따라 일정을 정리합니다.
+
+실제 서비스 연동은 각 fetcher 모듈의 TODO 부분을 구현해야 합니다.

--- a/aggregator/fetchers/gmail_fetcher.py
+++ b/aggregator/fetchers/gmail_fetcher.py
@@ -1,0 +1,6 @@
+"""Gmail 메시지 수집 모듈."""
+from typing import List
+
+def fetch_gmail_messages() -> List[str]:
+    # TODO: Gmail API 연동 후 메일 내용 반환
+    return []

--- a/aggregator/fetchers/instagram_fetcher.py
+++ b/aggregator/fetchers/instagram_fetcher.py
@@ -1,0 +1,6 @@
+"""Instagram DM 수집 모듈."""
+from typing import List
+
+def fetch_instagram_messages() -> List[str]:
+    # TODO: Instagram Graph API 또는 크롤링 구현
+    return []

--- a/aggregator/fetchers/kakao_fetcher.py
+++ b/aggregator/fetchers/kakao_fetcher.py
@@ -1,0 +1,6 @@
+"""KakaoTalk 메시지 수집 모듈."""
+from typing import List
+
+def fetch_kakao_messages() -> List[str]:
+    # TODO: KakaoTalk API 또는 크롤링 구현
+    return []

--- a/aggregator/fetchers/messenger_fetcher.py
+++ b/aggregator/fetchers/messenger_fetcher.py
@@ -1,0 +1,6 @@
+"""Meta Messenger 메시지 수집 모듈."""
+from typing import List
+
+def fetch_messenger_messages() -> List[str]:
+    # TODO: Meta Messenger API 연동
+    return []

--- a/aggregator/fetchers/portal_fetcher.py
+++ b/aggregator/fetchers/portal_fetcher.py
@@ -1,0 +1,6 @@
+"""학교/회사 포털 일정 수집 모듈."""
+from typing import List
+
+def fetch_portal_messages() -> List[str]:
+    # TODO: 포털 사이트 크롤링 또는 API 연동
+    return []

--- a/aggregator/main.py
+++ b/aggregator/main.py
@@ -1,0 +1,56 @@
+import os
+import pytz
+import schedule
+import time
+from datetime import datetime
+
+from fetchers.gmail_fetcher import fetch_gmail_messages
+from fetchers.kakao_fetcher import fetch_kakao_messages
+from fetchers.messenger_fetcher import fetch_messenger_messages
+from fetchers.instagram_fetcher import fetch_instagram_messages
+from fetchers.portal_fetcher import fetch_portal_messages
+from parser import extract_events
+from markdown_writer import write_markdown
+
+KST = pytz.timezone('Asia/Seoul')
+VAULT_PATH = os.environ.get("VAULT_PATH", "vault")
+
+
+def collect_and_process():
+    raw_messages = []
+    raw_messages.extend(fetch_gmail_messages())
+    raw_messages.extend(fetch_kakao_messages())
+    raw_messages.extend(fetch_messenger_messages())
+    raw_messages.extend(fetch_instagram_messages())
+    raw_messages.extend(fetch_portal_messages())
+
+    events = []
+    for msg in raw_messages:
+        events.extend(extract_events(msg))
+
+    if events:
+        if not os.path.exists(VAULT_PATH):
+            os.makedirs(VAULT_PATH)
+        timestamp = datetime.now(KST).strftime("%Y-%m-%d")
+        filename = os.path.join(VAULT_PATH, f"schedule_{timestamp}.md")
+        write_markdown(filename, events)
+
+
+def daily_task():
+    response = input("오늘 일정을 정리했나요? (y/N): ")
+    if response.strip().lower() == 'y':
+        collect_and_process()
+        print("일정을 정리했습니다.")
+    else:
+        print("다음에 다시 시도합니다.")
+
+
+def main():
+    schedule.every().day.at("22:00").do(daily_task)
+    while True:
+        schedule.run_pending()
+        time.sleep(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/aggregator/markdown_writer.py
+++ b/aggregator/markdown_writer.py
@@ -1,0 +1,8 @@
+"""Markdown 파일 생성 모듈."""
+from typing import List
+
+
+def write_markdown(filename: str, events: List[str]) -> None:
+    with open(filename, "a", encoding="utf-8") as f:
+        for event in events:
+            f.write(f"- {event}\n")

--- a/aggregator/parser.py
+++ b/aggregator/parser.py
@@ -1,0 +1,20 @@
+"""메시지에서 일정 및 할 일 추출 모듈."""
+from typing import List
+import re
+from datetime import datetime
+
+DATE_PATTERN = re.compile(r"(\d{4}-\d{2}-\d{2})")
+
+
+def extract_events(text: str) -> List[str]:
+    events = []
+    for line in text.splitlines():
+        match = DATE_PATTERN.search(line)
+        if match:
+            date_str = match.group(1)
+            try:
+                datetime.strptime(date_str, "%Y-%m-%d")
+                events.append(line.strip())
+            except ValueError:
+                continue
+    return events

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+schedule
+pytz


### PR DESCRIPTION
## Summary
- setup basic aggregator to collect messages from Gmail, KakaoTalk, Messenger, Instagram and a portal (currently placeholders)
- parse text for dates and produce Markdown files in a vault directory
- run every day at 22:00 KST
- document usage in Korean README
- add minimal requirements file

## Testing
- `python3 -m compileall -q aggregator`

------
https://chatgpt.com/codex/tasks/task_e_683ff6131f788324becfe7d20f8ff41e